### PR TITLE
helm chart for tesla-fleet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ LINTER_FLAGS ?=
 ALPHA_IMAGE_NAME=fleet-telemetry-server-aplha:v0.0.1
 ALPHA_IMAGE_COMPRESSED_FILENAME := $(subst :,-, $(ALPHA_IMAGE_NAME))
 
+WG_IMAGE_REPO := 464910097692.dkr.ecr.us-west-2.amazonaws.com/tesla_fleet
+
 GO_FLAGS        ?=
 GO_FLAGS        += --ldflags 'extldflags="-static"'
 
@@ -79,3 +81,9 @@ image-gen:
 	docker save $(ALPHA_IMAGE_NAME) | gzip > $(ALPHA_IMAGE_COMPRESSED_FILENAME).tar.gz
 
 .PHONY: test build vet linters install integration image-gen generate-protos generate-golang generate-python generate-ruby clean
+
+wg-build-image:
+	docker build --platform linux/amd64 -t $(WG_IMAGE_REPO):$(shell git rev-parse --short HEAD) .
+
+wg-push-image: wg-build-image
+	docker push $(WG_IMAGE_REPO):$(shell git rev-parse --short HEAD)

--- a/chart/.helmignore
+++ b/chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: fleet-telemetry
+description: An Open Source Helm chart for fleet-telemetry
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.0.3"

--- a/chart/README.md
+++ b/chart/README.md
@@ -1,0 +1,154 @@
+# Fleet Telemetry Helm Chart 
+* Installs the fleet-telemetry system. [fleet-telemetry](https://github.com/teslamotors/fleet-telemetry)
+## Get Repo Info
+```console
+helm repo add teslamotors https://teslamotors.github.io/helm-charts/
+helm repo update
+```
+_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
+
+## Installing the Chart
+
+To install the chart with the release name `fleet-telemetry`:
+
+```console
+helm install fleet-telemetry teslamotors/fleet-telemetry -n fleet-telemetry --create-namespace
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the fleet-telemetry deployment:
+
+```console
+helm uninstall fleet-telemetry -n fleet-telemetry
+```
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Upgrade the Chart
+To upgrade the chart with the release name `fleet-telemetry`:
+```console
+helm upgrade fleet-telemetry teslamotors/fleet-telemetry -n fleet-telemetry
+```
+
+## Configuration
+| Parameter             | Description                                                                         | Default                 |
+|-----------------------|-------------------------------------------------------------------------------------|-------------------------|
+| `tlsSecret.name`      | Name of existing secret, if this value is set `tlsCrt` and `tlsKey` will be ignored | `nil`                   |
+| `tlsSecret.tlsCrt`    | value of the certification                                                          | `nil`                   |
+| `tlsSecret.tlsKey`    | value of the encryption key                                                         | `nil`                   |
+| `image.repository`    | value of the docker image repo                                                      | `tesla/fleet-telemetry` |
+| `image.tag`           | value of the docker image tag                                                       | `latest`                |
+| `resources`           | CPU/Memory resource requests/limits                                                 | {}                      |
+| `nodeSelector`        | Node labels for pod assignment                                                      | {}                      |
+| `tolerations`         | Toleration labels for pod assignment                                                | {}                      |
+| `replicas`            | Number of pods                                                                      | `1`                     |
+| `service.annotations` | Service Annotations                                                                 | {}                      |
+| `service.type`        | Service Type                                                                        | ClusterIP               |
+
+## Example
+* Set `config.data` in `values.yaml`
+```yaml
+service:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb-ip"
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+    service.beta.kubernetes.io/aws-load-balancer-subnets: subnet-1, subnet-2, subnet-3
+  type: LoadBalancer
+tlsSecret:
+  tlsCrt: |
+    value of the cert PEM
+  tlsKey: |
+    value the private key
+config:
+  data: |
+    {
+      "host": "0.0.0.0",
+      "port": 8443,
+      "status_port": 8080,
+      "log_level": "info",
+      "json_log_enable": true,
+      "namespace": "tesla_telemetry",
+      "monitoring": {
+        "prometheus_metrics_port": 9273,
+        "profiler_port": 4269,
+        "profiling_path": "/tmp/trace.out"
+      },
+      "rate_limit": {
+        "enabled": true,
+        "message_interval_time": 30,
+        "message_limit": 1000
+      },
+      "records": {
+        "alerts": [
+          "logger"
+        ],
+        "errors": [
+          "logger"
+        ],
+        "V": [
+          "logger"
+        ]
+      },
+      "tls": {
+        "server_cert": "/etc/certs/server/tls.crt",
+        "server_key": "/etc/certs/server/tls.key"
+      }
+    }
+```
+```console
+helm install fleet-telemetry teslamotors/fleet-telemetry -n fleet-telemetry -f values.yaml
+```
+* Set `config.data` by `--set-file`
+```yaml
+service:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb-ip"
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+    service.beta.kubernetes.io/aws-load-balancer-subnets: subnet-1, subnet-2, subnet-3
+  type: LoadBalancer
+tlsSecret:
+  tlsCrt: |
+    value of the cert PEM
+  tlsKey: |
+    value the private key
+```
+```json
+{
+  "host": "0.0.0.0",
+  "port": 8443,
+  "status_port": 8080,
+  "log_level": "info",
+  "json_log_enable": true,
+  "namespace": "tesla_telemetry",
+  "monitoring": {
+    "prometheus_metrics_port": 9273,
+    "profiler_port": 4269,
+    "profiling_path": "/tmp/trace.out"
+  },
+  "rate_limit": {
+    "enabled": true,
+    "message_interval_time": 30,
+    "message_limit": 1000
+  },
+  "records": {
+    "alerts": [
+      "logger"
+    ],
+    "errors": [
+      "logger"
+    ],
+    "V": [
+      "logger"
+    ]
+  },
+  "tls": {
+    "server_cert": "/etc/certs/server/tls.crt",
+    "server_key": "/etc/certs/server/tls.key"
+  }
+}
+```
+```console
+helm install fleet-telemetry teslamotors/fleet-telemetry -n fleet-telemetry -f values.yaml --set-file config.data=config.json
+```

--- a/chart/install.sh
+++ b/chart/install.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+ENV=prod
+NAMESPACE=tesla-fleet
+RELEASE_NAME=tesla-fleet
+CHART_NAME=.
+
+helm upgrade --install -n "${NAMESPACE}" --create-namespace "${RELEASE_NAME}" \
+  -f values.yaml -f "${ENV}.yaml" "${CHART_NAME}"

--- a/chart/prod.yaml
+++ b/chart/prod.yaml
@@ -1,0 +1,5 @@
+service_role_arn: arn:aws:iam::464910097692:role/tesla-fleet-role-prod
+
+certificate:
+  dnsNames:
+    - tesla-fleet-v1.weavegrid.com

--- a/chart/stage.yaml
+++ b/chart/stage.yaml
@@ -1,0 +1,3 @@
+certificate:
+  dnsNames:
+    - tesla-fleet-v1.weavegrid.dev

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "fleet-telemetry.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "fleet-telemetry.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "fleet-telemetry.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "fleet-telemetry.labels" -}}
+helm.sh/chart: {{ include "fleet-telemetry.chart" . }}
+{{ include "fleet-telemetry.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "fleet-telemetry.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "fleet-telemetry.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "fleet-telemetry.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "fleet-telemetry.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/chart/templates/certificate.yaml
+++ b/chart/templates/certificate.yaml
@@ -1,0 +1,11 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "fleet-telemetry.fullname" . }}
+spec:
+  secretName: {{ printf "%s-tls" (include "fleet-telemetry.fullname" .) | quote }}
+  issuerRef:
+    name: {{ quote .Values.certificate.issuer }}
+    group: cert-manager.io
+    kind: ClusterIssuer
+  dnsNames: {{ toJson .Values.certificate.dnsNames }}

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "fleet-telemetry.fullname" . }}
+  labels:
+    service: fleet-telemetry
+  {{- include "fleet-telemetry.labels" . | nindent 4 }}
+data:
+  config.json: {{ .Values.config.data | toJson }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -1,0 +1,83 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "fleet-telemetry.fullname" . }}
+  labels:
+    role: api
+    service: fleet-telemetry
+  {{- include "fleet-telemetry.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      role: api
+      service: fleet-telemetry
+    {{- include "fleet-telemetry.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        role: api
+        service: fleet-telemetry
+      {{- include "fleet-telemetry.selectorLabels" . | nindent 8 }}
+      annotations:
+        config-hash: {{ .Values.config.data | toJson | sha256sum }}
+    spec:
+      containers:
+      - command:
+        - /fleet-telemetry
+        - -config=/etc/fleet-telemetry/config.json
+        env:
+        - name: KUBERNETES_CLUSTER_DOMAIN
+          value: {{ quote .Values.kubernetesClusterDomain }}
+        {{- range $key, $value := .Values.env }}
+        - name: {{ quote $key }}
+          value: {{ quote $value }}
+        {{- end }}
+        image: {{ printf "%s:%s" .Values.image.repository (.Values.image.tag | default .Chart.AppVersion) | quote }}
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /metrics
+            port: {{ .Values.config.metrics.port }}
+            scheme: HTTP
+          initialDelaySeconds: 5
+          timeoutSeconds: 10
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /status
+            port: {{ .Values.config.status.port }}
+            scheme: HTTP
+          initialDelaySeconds: 5
+          timeoutSeconds: 10
+        name: fleet-telemetry
+        ports:
+        - containerPort: {{ .Values.config.profile.port }}
+          name: profile
+          protocol: TCP
+        - containerPort: {{ .Values.config.port }}
+          name: https
+          protocol: TCP
+        - containerPort: {{ .Values.config.metrics.port }}
+          name: metrics
+          protocol: TCP
+        resources: {{- toYaml .Values.resources | nindent 10 }}
+        volumeMounts:
+        - mountPath: /etc/fleet-telemetry/
+          name: config
+        - mountPath: /etc/certs/server
+          name: server-certs
+      nodeSelector: {{- toYaml .Values.nodeSelector | nindent 8 }}
+      tolerations: {{- toYaml .Values.tolerations | nindent 8 }}
+      volumes:
+      - name: config
+        projected:
+          sources:
+          - configMap:
+              name: {{ include "fleet-telemetry.fullname" . }}
+      - name: server-certs
+        projected:
+          sources:
+          - secret:
+              name: {{ printf "%s-tls" (include "fleet-telemetry.fullname" .) | quote }}
+      serviceAccountName: {{ include "fleet-telemetry.fullname" . }}-sa

--- a/chart/templates/service-internal.yaml
+++ b/chart/templates/service-internal.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "fleet-telemetry.fullname" . }}-internal
+  labels:
+    prometheus_scrape: "true"
+    role: api
+    service: fleet-telemetry
+  {{- include "fleet-telemetry.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.serviceInternal.type }}
+  selector:
+    role: api
+    service: fleet-telemetry
+  {{- include "fleet-telemetry.selectorLabels" . | nindent 4 }}
+  ports:
+	{{- .Values.serviceInternal.ports | toYaml | nindent 2 -}}
+{{- if .Values.serviceInternal.monitor.create }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "fleet-telemetry.fullname" . }}
+  {{- with .Values.serviceInternal.monitor.labels }}
+  labels: {{ toJson . }}
+  {{- end }}
+spec:
+  # Select all services in namespace (if they have a metrics port)
+  selector:
+    matchLabels:
+      prometheus_scrape: "true"
+      role: api
+      service: fleet-telemetry
+      {{- include "fleet-telemetry.selectorLabels" . | nindent 6 }}
+  endpoints:
+  - port: metrics
+    interval: 15s
+    scrapeTimeout: 15s
+{{- end }}

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "fleet-telemetry.fullname" . }}
+  labels:
+    role: api
+    service: fleet-telemetry
+  {{- include "fleet-telemetry.labels" . | nindent 4 }}
+  annotations:
+    {{- .Values.service.annotations | toYaml | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    role: api
+    service: fleet-telemetry
+  {{- include "fleet-telemetry.selectorLabels" . | nindent 4 }}
+  ports:
+  {{- .Values.service.ports | toYaml | nindent 2 -}}

--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "fleet-telemetry.fullname" . }}-sa
+  labels:
+    {{- include "fleet-telemetry.labels" . | nindent 4 }}
+  annotations:
+    eks.amazonaws.com/role-arn: {{ tpl .Values.service_role_arn . | quote }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,0 +1,98 @@
+certificate:
+  issuer: letsencrypt-dns-prod
+  dnsNames:
+    - tesla-fleet-v1.weavegrid.com
+
+image:
+  repository: 464910097692.dkr.ecr.us-west-2.amazonaws.com/tesla_fleet
+  tag: 317f33a
+
+env:
+  AWS_REGION: us-west-2
+  SUPPRESS_TLS_HANDSHAKE_ERROR_LOGGING: "1"
+
+replicas: 1
+
+resources: {}
+nodeSelector: {}
+tolerations: []
+
+service:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-attributes: deletion_protection.enabled=true
+    service.beta.kubernetes.io/aws-load-balancer-name: tesla-fleet
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: instance
+    service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
+    service.beta.kubernetes.io/aws-load-balancer-type: external
+    service.beta.kubernetes.io/aws-load-balancer-healthcheck-interval: "300" # Remove this eventually
+  ports:
+    - name: https
+      port: 443
+      targetPort: 8443
+  type: LoadBalancer
+
+serviceInternal:
+  ports:
+    - name: metrics
+      port: 9273
+      targetPort: 9273
+    - name: profile
+      port: 4269
+      targetPort: 4269
+  type: ClusterIP
+  monitor:
+    create: true
+    labels:
+      release: kube-prom
+
+config:
+  data: |
+    {
+      "host": "0.0.0.0",
+      "port": 8443,
+      "status_port": 8080,
+      "log_level": "info",
+      "json_log_enable": true,
+      "namespace": "tesla_telemetry",
+      "monitoring": {
+        "prometheus_metrics_port": 9273,
+        "profiler_port": 4269,
+        "profiling_path": "/tmp/trace.out"
+      },
+      "kinesis": {
+        "max_retries": 3,
+        "streams": {
+          "V": "tesla-fleet-prod"
+        }
+      },
+      "rate_limit": {
+        "enabled": true,
+        "message_interval_time": 30,
+        "message_limit": 1000
+      },
+      "records": {
+        "alerts": [
+          "logger"
+        ],
+        "errors": [
+          "logger"
+        ],
+        "V": [
+          "kinesis",
+          "logger"
+        ]
+      },
+      "tls": {
+        "server_cert": "/etc/certs/server/tls.crt",
+        "server_key": "/etc/certs/server/tls.key"
+      }
+    }
+  port: 8443
+  status:
+    port: 8080
+  metrics:
+    port: 9273
+  profile:
+    port: 4269
+
+kubernetesClusterDomain: cluster.local

--- a/telemetry/record.go
+++ b/telemetry/record.go
@@ -97,7 +97,7 @@ func (record *Record) GetJSONPayload() ([]byte, error) {
 	if record.transmitDecodedRecords {
 		return record.Payload(), nil
 	}
-	return record.toJSON()
+	return record.ToJSON()
 }
 
 // Raw returns the raw telemetry record
@@ -192,7 +192,7 @@ func (record *Record) applyRecordTransforms() error {
 	if !record.transmitDecodedRecords {
 		return nil
 	}
-	record.PayloadBytes, err = record.toJSON()
+	record.PayloadBytes, err = record.ToJSON()
 	return err
 }
 
@@ -202,7 +202,7 @@ func (record *Record) GetProtoMessage() proto.Message {
 }
 
 // ToJSON serializes the record to a JSON data in bytes
-func (record *Record) toJSON() ([]byte, error) {
+func (record *Record) ToJSON() ([]byte, error) {
 	return jsonOptions.Marshal(record.protoMessage)
 }
 


### PR DESCRIPTION
Created a helm chart for the tesla-fleet deployment largely based off of https://github.com/teslamotors/helm-charts/blob/main/charts/fleet-telemetry/README.md

Main changes over that chart are
- It creates a certificate with cert-manager that it passes into the service instead of using a fixed key.
- Setup a service monitor for prometheus

Also updated the service itself to
- Output JSON to Kinesis instead of protocol buffers. Not sure if this will be temporary
- Remove the test call to ListStreams which was absurd

Possible todos
* It would be nice if this service didn't have to do TLS termination. If the mTLS only functions to validate the client vehicles we can likely move that functionality to e.g. Tyk.